### PR TITLE
Added support for single-module alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,31 @@ Then, the recommended way of using it is by using the file `.babelrc` to setup t
   }
 }
 ```
+
+Module aliasing also works for a single modules. Given this config in `.babelrc`:
+
+```
+{
+  "plugins": [
+    "babel-plugin-module-alias"
+  ],
+  "extra": {
+    "module-alias": [
+      {
+        "src": "../some-path/more-folders/my-awesome-lib",
+        "expose": "my-awesome-lib"
+      }
+    ]
+  }
+}
+```
+
+In your code you can simply do:
+
+```js
+import MyAwesomeLib from 'my-awesome-lib'; 
+```
+
 _Note:_ the section `extra` is a custom section commonly used by plugins to take options. There's currently no better way in Babel to pass options to plugins.
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-module-alias",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "description": "Babel plugin to rewrite the path in require() and ES6 import",
   "repository": "tleunen/babel-plugin-module-alias",

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function mapModule(context, module) {
     }
 
     var moduleSplit = module.split('/');
-    if(moduleSplit.length < 2 || !filesMap.hasOwnProperty(moduleSplit[0])) {
+    if(!filesMap.hasOwnProperty(moduleSplit[0])) {
         return;
     }
 


### PR DESCRIPTION
Currently it's impossible to alias a single module instead of the folder. This PR removes one of the checks allowing you to do so.