### PR TITLE
Can map for process that changes cwd.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,19 @@ function createFilesMap(state) {
     return result;
 }
 
+export function mapToRelative(currentFile, module) {
+    let from = path.dirname(currentFile);
+    let to = path.normalize(module);
+
+    from = path.isAbsolute(from) ? from : path.resolve(process.env.PWD, from);
+    to = path.isAbsolute(to) ? to : path.resolve(process.env.PWD, to);
+
+    let moduleMapped = path.relative(from, to);
+
+    if(moduleMapped[0] !== '.') moduleMapped = './' + moduleMapped;
+    return moduleMapped;
+}
+
 function mapModule(modulePath, state, filesMap) {
     const moduleSplit = modulePath.split('/');
 
@@ -20,12 +33,8 @@ function mapModule(modulePath, state, filesMap) {
         return null;
     }
 
-    const currentFile = state.file.opts.filename;
     moduleSplit[0] = filesMap[moduleSplit[0]];
-    let moduleMapped = path.relative(path.dirname(currentFile), path.normalize(moduleSplit.join('/')));
-
-    if(moduleMapped[0] !== '.') moduleMapped = './' + moduleMapped;
-    return moduleMapped;
+    return mapToRelative(state.file.opts.filename, moduleSplit.join('/'));
 }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
 import path from 'path';
-import process from 'process';
 
 import assert from 'assert';
 import { transform } from 'babel-core';

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,10 @@
 /* eslint-env mocha */
+import path from 'path';
+import process from 'process';
+
 import assert from 'assert';
 import { transform } from 'babel-core';
-import plugin from '../src';
+import plugin, { mapToRelative } from '../src';
 
 describe('Babel plugin module alias', () => {
     const transformerOpts = {
@@ -60,6 +63,32 @@ describe('Babel plugin module alias', () => {
             const result = transform(code, transformerOpts);
 
             assert.equal(result.code, 'import otherLib from "other-lib";');
+        });
+    });
+
+    describe('should map to relative path when cwd has been changed', () => {
+        const cwd = process.cwd();
+
+        before(() => {
+            process.chdir(path.join(process.env.PWD, './test'));
+        });
+
+        after(() => {
+            process.chdir(cwd);
+        });
+
+        it('with relative filename', () => {
+            const currentFile = './utils/test/file.js';
+            const result = mapToRelative(currentFile, 'utils/dep');
+
+            assert.equal(result, '../dep');
+        });
+
+        it('with absolute filename', () => {
+            const currentFile = path.join(process.env.PWD, './utils/test/file.js');
+            const result = mapToRelative(currentFile, 'utils/dep');
+
+            assert.equal(result, '../dep');
         });
     });
 });


### PR DESCRIPTION
We've been trying to use this plugin with projects that use [AVA](http://ava.li) for testing.

AVA uses child processes and sets `cwd` to the directory of the current test file. Thus, `state.file.opts.filename` would be an absolute path and the plugin wouldn't map the module correctly.

This PR is an attempt to fix that issue.