### PR TITLE
Converting process.env.PWD to process.cwd() to fix path issues on win…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,8 @@ export function mapToRelative(currentFile, module) {
     let from = path.dirname(currentFile);
     let to = path.normalize(module);
 
-    from = path.isAbsolute(from) ? from : path.resolve(process.env.PWD, from);
-    to = path.isAbsolute(to) ? to : path.resolve(process.env.PWD, to);
+    from = path.isAbsolute(from) ? from : path.resolve(process.cwd(), from);
+    to = path.isAbsolute(to) ? to : path.resolve(process.cwd(), to);
 
     let moduleMapped = path.relative(from, to);
 

--- a/test/index.js
+++ b/test/index.js
@@ -84,7 +84,7 @@ describe('Babel plugin module alias', () => {
         });
 
         it('with absolute filename', () => {
-            const currentFile = path.join(process.env.PWD, './utils/test/file.js');
+            const currentFile = path.join(process.cwd(), './utils/test/file.js');
             const result = mapToRelative(currentFile, 'utils/dep');
 
             assert.equal(result, '../dep');


### PR DESCRIPTION
Makes the plugin work on windows again. Hard to "publish" because custom babel-plugin script used. But running this on windows and mac works in our projects